### PR TITLE
GroovyDoodContainer.groovy added, shading improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,22 @@
 
     <groupId>com.eficode</groupId>
     <artifactId>devstack</artifactId>
-    <version>2.3.7-SNAPSHOT</version>
+    <version>2.3.8-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>DevStack</name>
 
     <description>A series of scripts for setting up common developer application suites</description>
 
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <groovy.major.version>3.0</groovy.major.version>
+        <groovy.version>[3.0,4.0)</groovy.version>
+        <spock-core.version>2.4-M1-groovy-${groovy.major.version}</spock-core.version>
+        <jiraShortcuts.version>2.0.3-SNAPSHOT-groovy-3.0</jiraShortcuts.version>
+        <bitbucketinstancemanager.version>0.0.3-SNAPSHOT-groovy-3.0</bitbucketinstancemanager.version>
+    </properties>
 
 
     <dependencies>
@@ -95,11 +104,13 @@
         </dependency>
 
 
+        <!-- https://mvnrepository.com/artifact/de.gesellix/docker-client -->
         <dependency>
             <groupId>de.gesellix</groupId>
             <artifactId>docker-client</artifactId>
-            <version>2023-05-07T23-22-00</version>
+            <version>2023-08-16T08-25-00</version>
         </dependency>
+
 
         <!--dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -154,7 +165,7 @@
                 <!-- Configured in pluginManagement instead of plugins, because we do not want a shaded parent POM -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -175,6 +186,7 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/*.MF</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
@@ -184,14 +196,10 @@
                                     <exclude>org.codehaus.groovy:*</exclude>
                                     <!--exclude>org.codehaus.groovy:groovy</exclude>
                                     <exclude>org.codehaus.groovy:groovy-astbuilder</exclude-->
-
                                     <exclude>com.google.code.gson:gson</exclude>
                                     <exclude>org.apache.httpcomponents</exclude>
-
                                     <!--exclude>commons-*</exclude--> <!--Seems to break JenkinsAndHarborDeployment.groovy:103, needs org/apache/commons/io/FileUtils-->
-
                                     <exclude>com.kohlschutter.junixsocket:junixsocket-core</exclude>
-
                                 </excludes>
 
                             </artifactSet>
@@ -200,12 +208,20 @@
                                     <pattern>com.eficode.atlassian</pattern>
                                     <shadedPattern>com.eficode.shaded.atlassian</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>okio</pattern>
+                                    <shadedPattern>com.eficode.shaded.okio</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>okhttp3</pattern>
+                                    <shadedPattern>com.eficode.shaded.okhttp3</shadedPattern>
+                                </relocation>
                             </relocations>
 
                             <!-- NOTE: Any dependencies of the project will not show up in the standalone pom.
                             This means that if those dependencies are not properly relocated and there is a class-loading conflict,
                             user would not be able to figure out where the conflicting dependency is. -->
-                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
 
                             <createSourcesJar>true</createSourcesJar>
                         </configuration>
@@ -264,29 +280,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-
-        <profile>
-            <id>groovy-3</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <maven.compiler.source>11</maven.compiler.source>
-                <maven.compiler.target>11</maven.compiler.target>
-                <groovy.major.version>3.0</groovy.major.version>
-                <groovy.version>[3.0,4.0)</groovy.version>
-                <spock-core.version>2.4-M1-groovy-${groovy.major.version}</spock-core.version>
-                <jiraShortcuts.version>2.0.3-SNAPSHOT-groovy-3.0</jiraShortcuts.version>
-                <bitbucketinstancemanager.version>0.0.3-SNAPSHOT-groovy-3.0</bitbucketinstancemanager.version>
-            </properties>
-        </profile>
-
-
-
-    </profiles>
-
-
 
 </project>

--- a/src/main/groovy/com/eficode/devstack/container/Container.groovy
+++ b/src/main/groovy/com/eficode/devstack/container/Container.groovy
@@ -55,6 +55,12 @@ trait Container {
     ArrayList<Mount> mounts = []
 
 
+    /**
+     * Prior to create a container, prepare mount-points
+     * @param sourceAbs The source directory in the docker engine
+     * @param target The target directory inside the container
+     * @param readOnly
+     */
     void prepareBindMount(String sourceAbs, String target, boolean readOnly = true) {
 
         Mount newMount = new Mount().tap { m ->
@@ -134,6 +140,15 @@ trait Container {
         containerId = response.content.id
         return containerId
 
+    }
+
+
+    /**
+     * Will create a Container that will sleep indefinitely, ie wont shut of once entrypoint has finished executing
+     * @return container id
+     */
+    String createSleepyContainer() {
+        return createContainer([], ["tail", "-f", "/dev/null"])
     }
 
 

--- a/src/main/groovy/com/eficode/devstack/container/impl/AlpineContainer.groovy
+++ b/src/main/groovy/com/eficode/devstack/container/impl/AlpineContainer.groovy
@@ -25,13 +25,7 @@ class AlpineContainer implements Container {
         }
     }
 
-    /**
-     * Will create an Alpine Container that will sleep indefinitely
-     * @return
-     */
-    String createSleepyContainer() {
-        return createContainer([], ["tail", "-f", "/dev/null"])
-    }
+
 
 
 

--- a/src/main/groovy/com/eficode/devstack/container/impl/GroovyDoodContainer.groovy
+++ b/src/main/groovy/com/eficode/devstack/container/impl/GroovyDoodContainer.groovy
@@ -1,0 +1,18 @@
+package com.eficode.devstack.container.impl
+
+class GroovyDoodContainer extends DoodContainer{
+
+    String containerName = "GroovyDood"
+    String containerMainPort = ""
+    String containerImage = "groovy"
+    String containerImageTag = "jdk11-jammy"
+
+
+
+    @Override
+    boolean runAfterDockerSetup() {
+        return changeDockerSockOwner()
+    }
+
+}
+

--- a/src/main/groovy/com/eficode/devstack/container/impl/UbuntuContainer.groovy
+++ b/src/main/groovy/com/eficode/devstack/container/impl/UbuntuContainer.groovy
@@ -1,0 +1,15 @@
+package com.eficode.devstack.container.impl
+
+class UbuntuContainer extends AlpineContainer{
+
+    String containerName = "Ubuntu"
+    String containerImage = "ubuntu"
+    String defaultShell = "/bin/bash"
+
+
+    UbuntuContainer(String dockerHost = "", String dockerCertPath = "") {
+        if (dockerHost && dockerCertPath) {
+            assert setupSecureRemoteConnection(dockerHost, dockerCertPath): "Error setting up secure remote docker connection"
+        }
+    }
+}


### PR DESCRIPTION
 * Added changeDockerSockOwner() GroovyDoodContainer.groovy
 * New container intended to be used when groovy needs access to docker engine UbuntuContainer.groovy
 * A new basic ubuntu container Container.groovy
 * Improved documentation
 * Added createSleepyContainer() pom.xml
 * Bumped to 2.3.8
 * Bumped docker-client 2023-05-07T23-22-00 -> 2023-08-16T08-25-00
 * Tweaked maven-shade to work better both as standalone as "normal"