### PR TITLE
2.3.11 - Snapshot/Volume capabilities, GroovyBuilderDeployment, TimeMachine fixes etc

### DIFF
--- a/.github/buildScripts/shadingConf.xml
+++ b/.github/buildScripts/shadingConf.xml
@@ -53,6 +53,10 @@
                         <pattern>okhttp3</pattern>
                         <shadedPattern>com.eficode.shaded.okhttp3</shadedPattern>
                     </relocation>
+                    <relocation>
+                        <pattern>kotlinx.coroutines</pattern>
+                        <shadedPattern>com.eficode.shaded.kotlinx.coroutines</shadedPattern>
+                    </relocation>
                 </relocations>
 
                 <!-- NOTE: Any dependencies of the project will not show up in the standalone pom.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.eficode</groupId>
     <artifactId>devstack</artifactId>
-    <version>2.3.10-SNAPSHOT</version>
+    <version>2.3.11-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>DevStack</name>
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.eficode.atlassian</groupId>
             <artifactId>jirainstancemanager</artifactId>
-            <version>2.0.1-SNAPSHOT</version>
+            <version>2.0.3-SNAPSHOT</version>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.eficode</groupId>
     <artifactId>devstack</artifactId>
-    <version>2.3.9-SNAPSHOT</version>
+    <version>2.3.10-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>DevStack</name>

--- a/src/main/groovy/com/eficode/devstack/container/Container.groovy
+++ b/src/main/groovy/com/eficode/devstack/container/Container.groovy
@@ -366,14 +366,18 @@ trait Container {
 
     }
 
-    boolean stopContainer() {
+    boolean stopContainer(Integer timeoutS = 15) {
         log.info("Stopping container:" + self.containerId)
-        running ? dockerClient.stop(self.containerId, 15) : ""
+        long start = System.currentTimeSeconds()
+        running ? dockerClient.stop(self.containerId, timeoutS) : ""
+
         if (running) {
             log.warn("\tFailed to stop container" + self.containerId)
+            log.warn("Gave up waiting to shutdown ${shortId} after ${System.currentTimeSeconds() - start} seconds")
             return false
         } else {
             log.info("\tContainer stopped")
+            log.debug("\t\tContainer ${shortId} stopped after ${System.currentTimeSeconds() - start} seconds")
             return true
         }
     }

--- a/src/main/groovy/com/eficode/devstack/container/Container.groovy
+++ b/src/main/groovy/com/eficode/devstack/container/Container.groovy
@@ -235,11 +235,11 @@ trait Container {
      * @return
      */
     String getShortId() {
-        return containerId.substring(0,12)
+        return getContainerId().substring(0,12)
     }
 
     String getId() {
-        return containerId
+        return getContainerId()
     }
 
     Container getSelf() {

--- a/src/main/groovy/com/eficode/devstack/container/Container.groovy
+++ b/src/main/groovy/com/eficode/devstack/container/Container.groovy
@@ -13,7 +13,6 @@ import de.gesellix.docker.remote.api.ContainerSummary
 import de.gesellix.docker.remote.api.EndpointSettings
 import de.gesellix.docker.remote.api.ExecConfig
 import de.gesellix.docker.remote.api.HostConfig
-import de.gesellix.docker.remote.api.IdResponse
 import de.gesellix.docker.remote.api.Mount
 import de.gesellix.docker.remote.api.Network
 import de.gesellix.docker.remote.api.NetworkCreateRequest
@@ -75,6 +74,26 @@ trait Container {
         }
     }
 
+    /**
+     * Prepare mounting of an existing or new volume
+     * @param volumeName The name of the volume to create, or an existing one to mount
+     * @param target Where to mount it in the container
+     * @param readOnly If it should be read only or not
+     */
+    void prepareVolumeMount(String volumeName, String target, boolean readOnly = true) {
+
+        Mount newMount = new Mount().tap { m ->
+            m.source = volumeName
+            m.target = target
+            m.readOnly = readOnly
+            m.type = Mount.Type.Volume
+        }
+
+        if (!self.mounts.find { it.source == volumeName && it.target == target }) {
+            self.mounts.add(newMount)
+        }
+    }
+
 
     ContainerCreateRequest setupContainerCreateRequest() {
 
@@ -124,7 +143,7 @@ trait Container {
         ContainerCreateRequest containerCreateRequest = setupContainerCreateRequest()
 
         if (cmd.size()) {
-            containerCreateRequest.cmd = cmd.collect {it.toString()}
+            containerCreateRequest.cmd = cmd.collect { it.toString() }
         }
 
         if (entrypoint.size()) {
@@ -342,16 +361,16 @@ trait Container {
     }
 
 
-    File createTar(ArrayList<String> filePaths, String outputPath) {
+    File createTar(ArrayList<String> filePaths, String outputPath, ArrayList<String> ignorePaths = []) {
 
 
         log.info("Creating tar file:" + outputPath)
         log.debug("\tUsing source paths:")
         filePaths.each { log.debug("\t\t$it") }
 
-
         File outputFile = new File(outputPath)
         TarArchiveOutputStream tarArchive = new TarArchiveOutputStream(Files.newOutputStream(outputFile.toPath()))
+        tarArchive.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX)
 
         log.info("\tProcessing files")
         filePaths.each { filePath ->
@@ -368,28 +387,40 @@ trait Container {
 
                     String path = ResourceGroovyMethods.relativePath(newEntryFile, subFile)
                     log.trace("\t" * 4 + "Processing sub file:" + path)
-                    TarArchiveEntry entry = new TarArchiveEntry(subFile, path)
-                    entry.setSize(subFile.size())
-                    tarArchive.putArchiveEntry(entry)
-                    tarArchive.write(subFile.bytes)
-                    tarArchive.closeArchiveEntry()
-                    log.trace("\t" * 5 + "Added to archive")
+                    if (ignorePaths.any { subFile.absolutePath.matches(it) }) {
+                        log.trace("\t" * 5 + "File matches a path that is to be ignored, will not process further")
+                    } else {
+                        TarArchiveEntry entry = new TarArchiveEntry(subFile, path)
+                        entry.setSize(subFile.size())
+                        tarArchive.putArchiveEntry(entry)
+                        tarArchive.write(subFile.bytes)
+                        tarArchive.closeArchiveEntry()
+                        log.trace("\t" * 5 + "Added to archive")
+                    }
+
+
                 }
             } else {
                 log.trace("\t" * 4 + "Processing file:" + newEntryFile.name)
-                TarArchiveEntry entry = new TarArchiveEntry(newEntryFile, newEntryFile.name)
-                entry.setSize(newEntryFile.size())
-                tarArchive.putArchiveEntry(entry)
-                tarArchive.write(newEntryFile.bytes)
-                tarArchive.closeArchiveEntry()
-                log.trace("\t" * 5 + "Added to archive")
 
+                if (ignorePaths.any { newEntryFile.absolutePath.matches(it) }) {
+                    log.trace("\t" * 5 + "File matches a path that is to be ignored, will not process further")
+                }else {
+                    TarArchiveEntry entry = new TarArchiveEntry(newEntryFile, newEntryFile.name)
+                    entry.setSize(newEntryFile.size())
+                    tarArchive.putArchiveEntry(entry)
+                    tarArchive.write(newEntryFile.bytes)
+                    tarArchive.closeArchiveEntry()
+                    log.trace("\t" * 5 + "Added to archive")
+                }
             }
 
 
         }
 
         tarArchive.finish()
+        log.info("\tFinished creating TAR file:" + outputFile.absolutePath)
+        log.debug("\t\t" + (outputFile.size() / (1024 * 1024)).round() + "MB")
 
         return outputFile
 
@@ -426,6 +457,15 @@ trait Container {
         }
 
         return outFiles
+    }
+
+
+    /**
+     * Gets the home path for the containers default user
+     * @return ex: /home/user
+     */
+    String getHomePath() {
+        runBashCommandInContainer("pwd").find {true}
     }
 
 
@@ -637,12 +677,12 @@ trait Container {
     boolean replaceFileInContainer(String content, String filePath, boolean verify = false) {
         ArrayList<String> out = runBashCommandInContainer("cat > $filePath <<- 'EOF'\n" + content + "\nEOF")
 
-        assert out.isEmpty() : "Unexpected output when replacing file $filePath: " + out.join("\n")
+        assert out.isEmpty(): "Unexpected output when replacing file $filePath: " + out.join("\n")
 
         if (verify) {
-            ArrayList<String>rawOut = runBashCommandInContainer("cat " + filePath)
+            ArrayList<String> rawOut = runBashCommandInContainer("cat " + filePath)
             String readOut = rawOut.join()
-            assert readOut.trim() == content.trim() : "Error when verifying that the file $filePath was replaced"
+            assert readOut.trim() == content.trim(): "Error when verifying that the file $filePath was replaced"
             return true
         }
 
@@ -672,10 +712,18 @@ trait Container {
 
     }
 
-    boolean copyFileToContainer(String srcFilePath, String destinationDirectory) {
+    /**
+     * Creates a temporary tar, copies it to the container and extracts it there
+     * @param srcFilePath Local path to copy, will find directories/files recursively
+     * @param destinationDirectory The destination path in the container, must already exist and be absolut
+     * @param ignorePaths If these regex patterns matches the path/name of a file it wont be copied over.
+     *          ex: [".*\\.git.*"]
+     * @return true on success
+     */
+    boolean copyFileToContainer(String srcFilePath, String destinationDirectory, ArrayList<String> ignorePaths = []) {
 
 
-        File tarFile = createTar([srcFilePath], Files.createTempFile("docker_upload", ".tar").toString())
+        File tarFile = createTar([srcFilePath], Files.createTempFile("docker_upload", ".tar").toString(), ignorePaths)
         dockerClient.putArchive(self.containerId, destinationDirectory, tarFile.newDataInputStream())
 
         return tarFile.delete()
@@ -684,6 +732,8 @@ trait Container {
 
     static class ContainerCallback<T> implements StreamCallback<T> {
 
+
+        Logger log = LoggerFactory.getLogger(ContainerCallback.class)
         ArrayList<String> output = []
 
         @Override
@@ -693,6 +743,7 @@ trait Container {
             } else {
                 output.add(o.toString())
             }
+            log.debug(output.last())
 
         }
     }
@@ -759,7 +810,6 @@ trait Container {
     }
 
 
-
     /**
      * Creates a temporary container, runs a command, exits and removes container
      * @param container a container object that hasnt yet been created
@@ -774,7 +824,7 @@ trait Container {
      * @param dockerCertPath
      * @return An array of the container logs, or just an array containing container id if timeoutMs == 0
      */
-    static ArrayList<String> runCmdAndRm( ArrayList<String> cmd, long timeoutMs, ArrayList<Map> mounts = [], String dockerHost = "", String dockerCertPath = "") {
+    static ArrayList<String> runCmdAndRm(ArrayList<String> cmd, long timeoutMs, ArrayList<Map> mounts = [], String dockerHost = "", String dockerCertPath = "") {
 
 
         Container container = this.getConstructor(String, String).newInstance(dockerHost, dockerCertPath)
@@ -782,10 +832,8 @@ trait Container {
         Logger log = LoggerFactory.getLogger(this.class)
 
 
-
         log.info("Creating a $container.class.simpleName and running:")
         log.info("\tCmd:" + cmd)
-
 
 
         try {
@@ -821,13 +869,12 @@ trait Container {
             log.info("\tContainer finisehd or timed out after ${System.currentTimeMillis() - start}ms")
 
             if (container.running) {
-                log.info("\t"*2 + "Stopping container forcefully.")
+                log.info("\t" * 2 + "Stopping container forcefully.")
                 ArrayList<String> containerOut = container.containerLogs
                 assert container.stopAndRemoveContainer(1): "Error stopping and removing CMD container after it timed out"
 
                 throw new TimeoutException("CMD container timed out, was forcefully stopped and removed. Container logs:" + containerOut?.join("\n"))
             }
-
 
 
             ArrayList<String> containerOut = container.containerLogs
@@ -843,8 +890,8 @@ trait Container {
 
             try {
                 container.stopAndRemoveContainer(1)
-            } catch (ignored){}
-
+            } catch (ignored) {
+            }
 
 
             throw ex

--- a/src/main/groovy/com/eficode/devstack/container/impl/BitbucketContainer.groovy
+++ b/src/main/groovy/com/eficode/devstack/container/impl/BitbucketContainer.groovy
@@ -2,7 +2,6 @@ package com.eficode.devstack.container.impl
 
 import com.eficode.devstack.container.Container
 import com.eficode.devstack.util.ImageBuilder
-import de.gesellix.docker.client.EngineResponseContent
 import de.gesellix.docker.remote.api.ContainerCreateRequest
 import de.gesellix.docker.remote.api.HostConfig
 import de.gesellix.docker.remote.api.ImageSummary
@@ -71,7 +70,7 @@ class BitbucketContainer implements Container {
             c.exposedPorts = [(containerMainPort + "/tcp"): [:]]
             c.hostConfig = new HostConfig().tap { h ->
                 h.portBindings = [(containerMainPort + "/tcp"): [new PortBinding("0.0.0.0", (containerMainPort))]]
-                h.mounts = this.mounts
+                h.mounts = this.preparedMounts
             }
             c.hostname = containerName
             c.env = ["JVM_MAXIMUM_MEMORY=" + jvmMaxRam + "m", "JVM_MINIMUM_MEMORY=" + ((jvmMaxRam / 2) as String) + "m", "SETUP_BASEURL=" + baseUrl, "SERVER_PORT=" + containerMainPort] + customEnvVar

--- a/src/main/groovy/com/eficode/devstack/container/impl/GroovyContainer.groovy
+++ b/src/main/groovy/com/eficode/devstack/container/impl/GroovyContainer.groovy
@@ -1,6 +1,9 @@
 package com.eficode.devstack.container.impl
 import com.eficode.devstack.container.Container
 
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
 
 class GroovyContainer implements Container{
 
@@ -8,6 +11,11 @@ class GroovyContainer implements Container{
     String containerMainPort = ""
     String containerImage = "groovy"
     String containerImageTag = "latest"
+
+    boolean installMavenOnStartup
+    boolean installGitOnStartup
+    static final String mvnUrl = "https://dlcdn.apache.org/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.tar.gz"
+    static  final String mavenNameAndVersion = mvnUrl.substring(mvnUrl.lastIndexOf("/") + 1,mvnUrl.lastIndexOf("-bin.tar.gz")) //ex: apache-maven-3.9.0
 
 
     GroovyContainer(String dockerHost = "", String dockerCertPath = "") {
@@ -39,15 +47,235 @@ class GroovyContainer implements Container{
         return createContainer([],["/bin/bash" ,"-c" ,"trap \"exit\" SIGINT SIGTERM && tail -F /var/log/*  /var/log/userScript.log"])
     }
 
+    /**
+     * Creates a container intended for building Groovy maven projects
+     * @return Container id
+     */
+    String createGroovyBuildContainer() {
+
+
+        prepareCustomEnvVar(["PATH=/opt/$mavenNameAndVersion/bin:/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".toString()])
+        installMavenOnStartup = true
+        installGitOnStartup = true
+        return createContainer([],["/bin/bash" ,"-c" ,"trap \"exit\" SIGINT SIGTERM && tail -F /var/log/*  /var/log/userScript.log"])
+    }
+
     void useGroovy3() {
         this.containerImageTag = "3.0-jdk11-jammy"
     }
 
+    /**
+     * Set the intended groovy version of a new container
+     * @param version
+     */
     void setGroovyVersion(String version) {
+
+        if (version == "latest") {
+            this.containerImageTag = version
+        }else {
         this.containerImageTag = "$version-jdk11-jammy"
+    }
+
+    }
+
+
+    /**
+     * Used to mount the local m2 cache, useful for speeding up maven dependency fetching
+     * Will mount container path /home/groovy/.m2/repository
+     * <b>NOTE</b> will mount readOnly = false
+     * @param srcPath, defaults to $USERHOME/.m2/repository
+     */
+    void setUseLocalM2Cache(String srcPath = "") {
+
+        String sourcePath = srcPath ?: System.getProperty("user.home") + "/.m2/repository"
+        prepareBindMount(sourcePath, "/home/groovy/.m2/repository", false)
+    }
+
+
+    boolean installMaven() {
+        String mvnInstallScript = ""+
+                "wget -q $mvnUrl && " +
+                "tar -xvf ${mvnUrl.substring(mvnUrl.lastIndexOf("/") + 1)} && " +
+                "mv $mavenNameAndVersion /opt/ && echo Status:\$?"
+
+        ArrayList<String> cmdOut = runBashCommandInContainer(mvnInstallScript, 60000, "root")
+        assert cmdOut.contains("Status:0") : "Error installing maven"
+
+
+        assert runBashCommandInContainer("mvn --version" ).any {it.contains("/opt/$mavenNameAndVersion")} : "Error running maven after install"
+        assert runBashCommandInContainer("chown -R groovy:groovy /home/groovy && echo Status:\$?", 10000, "root").toString().contains("Status:0") : "Error changing groovy home owner"
+
+        return true
+    }
+
+    boolean installGit() {
+
+        String installGitScript = "" +
+                "apt update && " +
+                "apt install -y git && echo Status:\$?"
+
+        assert runBashCommandInContainer(installGitScript, 30000, "root").toString().contains("Status:0") : "Error install git"
+
+        assert runBashCommandInContainer("git --version && echo Status:\$?").toString().contains("Status:0") : "Error confirming git was installed"
+
+        return true
+
+    }
+
+    boolean isGitInstalled() {
+        return runBashCommandInContainer("which git && echo Status:\$?").toString().contains("Status:0")
+    }
+
+    /**
+     * Checks out a git repo
+     * @param gitUrl SSH or HTTP url to check out
+     * @param branch (optional) The branch to check out, if null the default one will be used
+     * @return The containers filepath to the checked out repo
+     */
+    String cloneGitRepo(String gitUrl, String branch=null) {
+
+        log.info("Cloning Git Repo")
+        log.info("\tCloning Git Repo:" + gitUrl)
+        log.info("\tUsing Git Branch:" + (branch ? branch : "(default)"))
+
+
+        if (!gitInstalled) {
+            log.info("\tGit is not installed, installing it now")
+            assert installGit() : "Error installing git"
+            log.debug("\t"*2 + "Finished installing git")
+        }
+
+        String repoName = gitUrl.substring(gitUrl.lastIndexOf("/")+1)
+        repoName = repoName.endsWith(".git") ? repoName[0..-5]  : repoName
+
+        String gitCloneCmd = "rm -rf $repoName && git clone ${branch ? "-b $branch " : ""}$gitUrl $repoName && echo Status:\$?"
+
+
+        log.info("\tStarting git clone")
+        log.debug("\t"*2 + "Using Git Cmd:" + gitCloneCmd)
+        long start = System.currentTimeSeconds()
+        ArrayList<String> cloneOutput = runBashCommandInContainer(gitCloneCmd, 120)
+        assert cloneOutput.toString().contains("Status:0") : "Error cloning Git Repo:" + cloneOutput.join("\n")
+        log.debug("\t"*2 + "Finished clone after:" + (System.currentTimeSeconds() - start))
+        String outputDir =  runBashCommandInContainer("cd $repoName && pwd").find {true}
+        assert outputDir : "Error determining git output dir"
+        log.info("\t"*2 + "Checked out repo to:" + outputDir)
+
+        return outputDir
+
+
+    }
+
+    /**
+     * Resolve the depencies of a Maven project.
+     * Usefull to pre-cache them
+     * @param projectRoot Where is the project root
+     * @param pomFile Name of the pom file to resolve dependencies for, located in $projectRoot, defaults to pom.xml
+     * @return true on success
+     */
+    boolean resolveMavenDependencies(String projectRoot, String pomFile = "pom.xml") {
+
+        log.info("Resolving Maven dependencies")
+        log.info("\tProject root:" + projectRoot)
+
+        log.debug("\t"*2 + "Starting dependency resolve")
+        long start = System.currentTimeSeconds()
+        ArrayList<String>resolveOut = runBashCommandInContainer("cd $projectRoot && mvn dependency:resolve -f $pomFile && echo Status:\$?", 1200)
+        log.debug("\t" *2 + "Finished resolve after " + (System.currentTimeSeconds()- start))
+        assert resolveOut.toString().contains("Status:0")
+
+        log.info("\tFinished resolving dependencies")
+
+        return true
+
+    }
+
+    /**
+     * Generate a new effective pom based on the profiles in a source pom
+     * @param projectRoot Root of the project where $srcPom is located
+     * @param mavenProfile The profil/profiles to use, ex: groovy-3,groovy-3.0.14
+     * @param dstPom The destination/output pom name
+     * @param srcPom (Optional) The src pom, defaults to pom.xml
+     * @return
+     */
+    boolean generateEffectivePom(String projectRoot, String mavenProfile, String dstPom = "effective-pom.xml", String srcPom = "pom.xml" ) {
+
+        log.info("Generating effective pom")
+        log.info("\tProject root:" + projectRoot)
+        log.info("\tUsing maven profile:" + mavenProfile)
+        log.info("\tSource Pom will be::" + srcPom)
+        log.info("\tDestination Pom will be::" + dstPom)
+
+        ArrayList<String>genOut = runBashCommandInContainer("cd $projectRoot && mvn help:effective-pom -f $srcPom -P $mavenProfile -Doutput=$dstPom && echo Status:\$?", 10)
+        assert genOut.toString().contains("Status:0") : "Error generating effective pom:" + genOut.join("\n")
+
+        return true
+
+    }
+
+
+    /**
+     * Run "maven install" for a project
+     * @param projectRoot Root of project
+     * @param pom (Optional) The pom file in projectRoot to use, defaults to pom.xml
+     * @param mavenParams Additional parameters to pass
+     * @return An array containing the complete file paths of the installed files (in the container)
+     */
+    ArrayList<String> installMavenProject(String projectRoot, String pom = "pom.xml", String mavenParams = "") {
+
+        log.info("Installing a maven project")
+        log.info("\tProject root:" + projectRoot)
+
+        ArrayList<String>installOut = runBashCommandInContainer("cd $projectRoot && mvn install -f $pom $mavenParams && echo Status:\$?", (5*60))
+
+        if (log.traceEnabled) {
+            log.trace("\tmvn install output:")
+            installOut.each {log.trace("\t"*2 + it)}
+        }
+        assert installOut.toString().contains("Status:0") : "Error generating effective pom:" + installOut.join("\n")
+        log.info("\tMaven installed finished")
+
+        log.debug("\tCollecting paths of installed files")
+        ArrayList<String>installedFiles = []
+        Pattern installPattern = ~/${projectRoot.replace("/", "\\/")}.*? to (.*)$/
+        installOut.findAll {it.contains( "Installing " + projectRoot)}.each {logRow ->
+
+            log.trace("\t"*2+ "Log row contains installed file:" + logRow)
+
+            Matcher matcher = logRow =~installPattern
+
+            ArrayList<String> matches = matcher.findAll {true}.flatten()
+            if (matches.size() == 2) {
+                installedFiles.add(matches[1])
+                log.trace("\t"*3 + "Extracted file path:" + matches[1])
+            }else {
+                log.warn("Error extracting installed file path from log:" + logRow)
+            }
+
+        }
+        log.info("\tDetected ${installedFiles.size()} files installed by maven")
+        log.info("\tFinished installing maven project")
+
+        return installedFiles
+
     }
 
 
 
+    @Override
+    boolean runOnFirstStartup() {
+
+        boolean success = true
+        if (installMavenOnStartup) {
+            success = success && installMaven()
+        }
+
+        if (installGitOnStartup) {
+            success = success && installGit()
+        }
+
+        return success
+
+    }
 
 }

--- a/src/main/groovy/com/eficode/devstack/container/impl/JsmContainer.groovy
+++ b/src/main/groovy/com/eficode/devstack/container/impl/JsmContainer.groovy
@@ -164,7 +164,9 @@ class JsmContainer implements Container {
      */
     Volume snapshotJiraHome(String snapshotName = "") {
         boolean wasRunning = running
-        stopContainer()
+
+        stopContainer(120)
+
 
         snapshotName = snapshotName ?: shortId + "-clone"
 

--- a/src/main/groovy/com/eficode/devstack/container/impl/JsmContainer.groovy
+++ b/src/main/groovy/com/eficode/devstack/container/impl/JsmContainer.groovy
@@ -2,12 +2,12 @@ package com.eficode.devstack.container.impl
 
 import com.eficode.devstack.container.Container
 import com.eficode.devstack.util.ImageBuilder
-import de.gesellix.docker.client.EngineResponseContent
 import de.gesellix.docker.remote.api.ContainerCreateRequest
 import de.gesellix.docker.remote.api.HostConfig
 import de.gesellix.docker.remote.api.ImageSummary
-import de.gesellix.docker.remote.api.NetworkingConfig
+import de.gesellix.docker.remote.api.MountPoint
 import de.gesellix.docker.remote.api.PortBinding
+import de.gesellix.docker.remote.api.Volume
 import kong.unirest.HttpResponse
 import kong.unirest.JsonResponse
 import kong.unirest.Unirest
@@ -98,7 +98,7 @@ class JsmContainer implements Container {
                 }
 
 
-                h.mounts = this.mounts
+                h.mounts = this.preparedMounts
             }
 
 
@@ -109,6 +109,86 @@ class JsmContainer implements Container {
 
     }
 
+
+    /**
+     * Returnes the mount point used for JIRA Home
+     * @return
+     */
+    MountPoint getJiraHomeMountPoint() {
+        return getMounts().find {it.destination == "/var/atlassian/application-data/jira"}
+    }
+
+
+    /**
+     * Restores JIRA home using a previoulsy made Snapshot/volume
+     * NOTE container will be stopped (and then restarted) if running
+     * @param snapshotName (Optional), defaults to $ShortID-clone but any volume name should work,
+     * @return True on success
+     */
+    boolean restoreJiraHomeSnapshot(String snapshotName = "") {
+
+        boolean wasRunning = running
+        stopContainer()
+        snapshotName = snapshotName ?: shortId + "-clone"
+
+        boolean success =  dockerClient.overwriteVolume(snapshotName, jiraHomeMountPoint.name)
+        if (wasRunning) {
+            startContainer()
+        }
+
+        return success
+
+    }
+
+
+    /**
+     * Snapshot JIRA home directory
+     * JIRA will be stopped if running, and started once snapshot is done
+     * @param snapshotName Name of the snapshot, will be deleted if already exists, will default to shortId + "-clone"
+     * @return the new Volume object
+     */
+    Volume snapshotJiraHome(String snapshotName = "") {
+        boolean wasRunning = running
+        stopContainer()
+
+        snapshotName = snapshotName ?: shortId + "-clone"
+
+        ArrayList<Volume> existingVolumes = dockerClient.getVolumesWithName(snapshotName)
+        existingVolumes.each {existingVolume ->
+            log.debug("\tRemoving existing snapshot volume:" + existingVolume.name)
+            dockerClient.manageVolume.rmVolume(existingVolume.name)
+        }
+
+        Volume newClone = cloneJiraHome(snapshotName)
+
+        if (wasRunning) {
+            startContainer()
+        }
+
+        return newClone
+    }
+
+    /**
+     * Clone JIRA home volume
+     * Container must be stopped
+     * @param newVolumeName must be unique
+     * @param labels, optional labels to add to the new volume
+     * @return
+     */
+    Volume cloneJiraHome(String newVolumeName = "", Map<String, Object> labels = null) {
+
+        newVolumeName = newVolumeName ?: shortId + "-clone"
+
+        labels = labels ?: [
+                srcContainerId : getId(),
+                created : System.currentTimeSeconds()
+        ] as Map
+
+        Volume newVolume = dockerClient.cloneVolume(jiraHomeMountPoint.name, newVolumeName, labels)
+
+        return newVolume
+
+    }
 
     boolean runOnFirstStartup() {
 

--- a/src/main/groovy/com/eficode/devstack/container/impl/JsmContainer.groovy
+++ b/src/main/groovy/com/eficode/devstack/container/impl/JsmContainer.groovy
@@ -140,6 +140,21 @@ class JsmContainer implements Container {
 
     }
 
+    Volume getSnapshotVolume(String snapshotName = "") {
+        snapshotName = snapshotName ?: shortId + "-clone"
+
+        ArrayList<Volume> volumes = dockerClient.getVolumesWithName(snapshotName)
+
+        if (volumes.size() == 1) {
+            return volumes.first()
+        }else if (volumes.isEmpty()) {
+            return null
+        }else {
+            throw new InputMismatchException("Error finding snapshot volume:" + snapshotName)
+        }
+
+    }
+
 
     /**
      * Snapshot JIRA home directory

--- a/src/main/groovy/com/eficode/devstack/deployment/impl/GroovyBuilderDeployment.groovy
+++ b/src/main/groovy/com/eficode/devstack/deployment/impl/GroovyBuilderDeployment.groovy
@@ -1,0 +1,165 @@
+package com.eficode.devstack.deployment.impl
+
+import com.eficode.devstack.container.Container
+import com.eficode.devstack.container.impl.GroovyContainer
+import com.eficode.devstack.deployment.Deployment
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class GroovyBuilderDeployment implements Deployment {
+
+    Logger log = LoggerFactory.getLogger(this.class)
+    String friendlyName = "Groovy Builder Deployment"
+    ArrayList<Container> containers = []
+    static String m2VolumeName = "groovy-m2-cache"
+    String dockerHost
+    String dockerCertPath
+
+
+    GroovyBuilderDeployment(String groovyVersion = "latest", String dockerHost = "", String dockerCertPath = "") {
+
+
+        containers = [new GroovyContainer(dockerHost, dockerCertPath)]
+        this.dockerHost = dockerHost
+        this.dockerCertPath = dockerCertPath
+        groovyContainer.setGroovyVersion(groovyVersion)
+        groovyContainer.setContainerName("groovyBuilder")
+    }
+
+    GroovyContainer getGroovyContainer() {
+        return  containers.find {it instanceof GroovyContainer} as GroovyContainer
+    }
+
+    @Override
+    boolean setupDeployment() {
+
+        groovyContainer.containerDefaultNetworks = [this.deploymentNetworkName]
+        groovyContainer.prepareVolumeMount(m2VolumeName, "/home/groovy/.m2/", false)
+        groovyContainer.createGroovyBuildContainer()
+        groovyContainer.startContainer()
+
+    }
+
+
+    static NginxFileServer buildAndHost(String localPath, String hostName = "repo.localhost", String port = "8081", String dockerNetwork = "bridge") {
+
+        GroovyBuilderDeployment groovyBuild = new GroovyBuilderDeployment()
+        groovyBuild.groovyContainer.containerName = "groovy-buildAndHost"
+        groovyBuild.setupDeployment()
+        groovyBuild.buildLocalSources(localPath)
+        groovyBuild.stopAndRemoveDeployment()
+
+        NginxFileServer fileServer = hostM2Volume(hostName, port, dockerNetwork, groovyBuild.m2VolumeName)
+
+        return fileServer
+    }
+
+
+    /**
+     * Creates an Nginx based file server
+     * @param hostName Will be used as container name and hostname
+     * @param port The port where nginx should listen
+     * @param dockerNetwork The name of the docker network that the file server should be attached to
+     * @param volumeName Name of the m2 docker volume to share
+     */
+    static NginxFileServer hostM2Volume(String hostName = "repo.localhost", String port = "8081", String dockerNetwork = "bridge", String volumeName = m2VolumeName) {
+
+        NginxFileServer nginx = new NginxFileServer()
+        nginx.setPort(port)
+        nginx.container.containerName = hostName
+        nginx.deploymentNetworkName = dockerNetwork
+        nginx.container.prepareVolumeMount(volumeName, "/usr/share/nginx/html", true)
+        nginx.setupDeployment()
+        nginx.startDeployment()
+
+
+        return nginx
+
+
+    }
+
+
+    /**
+     * Builds docker engine local source files in a groovy container
+     * @param localPath The local paths on the docker engine where sources are found, is expected to have a pom.xml file in the root
+     * @param mavenProfiles Optional maven profile to build
+     * @param ignorePaths Paths that should be ignored when copying files to the groovy container
+     * @return A list of built files in the docker container
+     */
+    ArrayList<String> buildLocalSources(String localPath, String mavenProfiles = "", ArrayList<String> ignorePaths = [".*\\.git.*", ".*target/.*", ".*\\.terraform/.*"]) {
+
+        String projectRoot = groovyContainer.getHomePath() + "/projectRoot/"
+
+        log.info("Building JARs from local sources")
+
+
+        groovyContainer.runBashCommandInContainer("rm -rf $projectRoot && mkdir -p $projectRoot")
+        assert groovyContainer.copyFileToContainer(localPath, projectRoot, ignorePaths)
+        groovyContainer.runBashCommandInContainer("chown groovy:groovy -R $projectRoot", 10, "root")
+
+
+        log.info("\tFinished checking copying sources from local path:" + localPath)
+
+        String pomFileName = "pom.xml"
+
+        //If maven profiles are supplied, we generate a new effective pom file
+        if (mavenProfiles) {
+            assert groovyContainer.generateEffectivePom(projectRoot, mavenProfiles, "effective-pom.xml") : "Error generating effective pom"
+            pomFileName = "effective-pom.xml"
+            log.debug("\tGenerated a new pom file based on Maven Profile(s):" + mavenProfiles )
+        }
+
+        log.info("\tResolving dependencies for pom: " + projectRoot + "/"+pomFileName)
+        groovyContainer.resolveMavenDependencies(projectRoot,pomFileName)
+        log.info("\t"* 2 + "Finished resolving dependencies")
+
+
+        ArrayList<String> installedFiles = groovyContainer.installMavenProject(projectRoot, pomFileName)
+
+        log.info("\tBuilt ${installedFiles.size()} files")
+        if (log.isDebugEnabled()) {
+            installedFiles.each {
+                log.debug("\t\t" + it)
+            }
+        }
+
+        return installedFiles
+    }
+
+
+
+
+
+    void buildGroovyJarsFromGit(String gitUrl, String gitBranch = "", String mavenProfiles = "") {
+
+        log.info("Building JARs from Git Repo")
+        String projectRoot = groovyContainer.cloneGitRepo(gitUrl, gitBranch)
+        log.info("\tFinished checking out git repo to container path:" + projectRoot)
+
+        String pomFileName = "pom.xml"
+
+        //If maven profiles are supplied, we generate a new effective pom file
+        if (mavenProfiles) {
+            assert groovyContainer.generateEffectivePom(projectRoot, mavenProfiles, "effective-pom.xml") : "Error generating effective pom"
+            pomFileName = "effective-pom.xml"
+            log.debug("\tGenerated a new pom file based on Maven Profile(s):" + mavenProfiles )
+        }
+
+        log.info("\tResolving dependencies for pom: " + projectRoot + "/"+pomFileName)
+        groovyContainer.resolveMavenDependencies(projectRoot,pomFileName)
+        log.info("\t"* 2 + "Finished resolving dependencies")
+
+
+        ArrayList<String> installedFiles = groovyContainer.installMavenProject(projectRoot, pomFileName)
+
+
+
+
+        ""
+
+
+
+    }
+
+
+}

--- a/src/main/groovy/com/eficode/devstack/deployment/impl/NginxFileServer.groovy
+++ b/src/main/groovy/com/eficode/devstack/deployment/impl/NginxFileServer.groovy
@@ -79,6 +79,7 @@ class NginxFileServer implements Deployment {
 
     @Override
     boolean setupDeployment() {
+        container.containerDefaultNetworks = [this.deploymentNetworkName]
         return  containers.first().createContainer() != null
     }
 }

--- a/src/main/groovy/com/eficode/devstack/util/DockerClientDS.groovy
+++ b/src/main/groovy/com/eficode/devstack/util/DockerClientDS.groovy
@@ -1,14 +1,19 @@
 package com.eficode.devstack.util
 
-import com.eficode.devstack.util.DockerClientDS
+import com.eficode.devstack.container.impl.UbuntuContainer
 import de.gesellix.docker.client.DockerClientImpl
 import de.gesellix.docker.client.EngineResponseContent
 import de.gesellix.docker.engine.DockerClientConfig
 import de.gesellix.docker.engine.DockerEnv
+import de.gesellix.docker.engine.EngineResponse
+import de.gesellix.docker.remote.api.ContainerSummary
 import de.gesellix.docker.remote.api.ExecConfig
 import de.gesellix.docker.remote.api.ExecStartConfig
 import de.gesellix.docker.remote.api.IdResponse
 import de.gesellix.docker.remote.api.SystemInfo
+import de.gesellix.docker.remote.api.Volume
+import de.gesellix.docker.remote.api.VolumeCreateOptions
+import de.gesellix.docker.remote.api.VolumeListResponse
 import de.gesellix.docker.remote.api.core.Frame
 import de.gesellix.docker.remote.api.core.StreamCallback
 import org.slf4j.Logger
@@ -56,6 +61,121 @@ class DockerClientDS extends DockerClientImpl {
         SystemInfo info = info().content
 
         return info.architecture
+
+    }
+
+
+    ArrayList<Volume> getVolumesWithLabel(String label) {
+        EngineResponseContent<VolumeListResponse> response = volumes("{\"label\":[\"$label\"]}")
+
+        return response?.content?.volumes
+    }
+
+
+    ArrayList<Volume> getVolumesWithName(String name) {
+        EngineResponseContent<VolumeListResponse> response = volumes("{\"name\":[\"$name\"]}")
+
+        return response?.content?.volumes
+    }
+
+
+    ArrayList<ContainerSummary> getContainersUsingVolume(Volume volume) {
+
+
+        EngineResponse response = ps(true, 1000, true, " {\"volume\":[\"${volume.name}\"]}")
+
+
+        ArrayList<ContainerSummary> containers = response.content
+        return containers
+
+
+    }
+
+
+    EngineResponseContent<Volume> createVolume(String name = null, Map<String, String> labels = null, Map<String, String> driverOpts = null) {
+        VolumeCreateOptions volumeOptions = new VolumeCreateOptions()
+
+        //Transform Gstring to regular string
+        labels = labels?.collectEntries { [(it.key.toString()): it.value.toString()] }
+        driverOpts = driverOpts?.collectEntries { [(it.key.toString()): it.value.toString()] }
+
+        volumeOptions.with { vol ->
+            vol.labels = labels
+            vol.name = name
+            vol.driverOpts = driverOpts
+        }
+
+
+        return createVolume(volumeOptions)
+
+
+    }
+
+
+    /**
+     * Clone a volume
+     * Clone is performed with a simple cp command, will fail if exotic file system is used
+     * The src volume must not be mounted to a container currently running
+     * @param srcVolumeName Name of the volume to copy
+     * @param destVolumeName Name of the destination volume. Must be unique and currently not created
+     * @param labels Labels of the new volume, null will leave them empty, [] will inherit from src
+     */
+    Volume cloneVolume(String srcVolumeName, String destVolumeName, Map<String, Object> labels = null) {
+
+        log.info("Cloning volume:" + srcVolumeName)
+
+        ArrayList<Volume> srcVolumes = getVolumesWithName(srcVolumeName).findAll { it.name == srcVolumeName }
+        assert srcVolumes.size() == 1: "Error finding source volume:" + srcVolumeName
+
+        Volume srcVolume = srcVolumes.first()
+
+        log.debug("\tSuccessfully identified volume to clone")
+
+        ArrayList<ContainerSummary> containersUsingSrc = getContainersUsingVolume(srcVolume)
+
+        assert containersUsingSrc.empty || containersUsingSrc.findAll { it.state == "running" }.isEmpty(): "Source volume is currently connected to a running container"
+
+
+        Map destLabels
+
+        switch (labels) {
+
+            case null:
+                destLabels = null
+                break
+            case []:
+                destLabels = srcVolume.labels
+                break
+            default:
+                destLabels = labels
+                break
+        }
+
+
+        Volume destVolume = getVolumesWithName(destVolumeName).find { it.name == destVolumeName }
+
+        assert destVolume == null: "Destination name is already in use"
+
+        destVolume = createVolume(destVolumeName, destLabels, srcVolume.options)?.content
+
+        assert destVolume: "Error creating Destination Volume"
+        log.info("\tCreated destination volume:" + destVolume.name)
+
+
+        UbuntuContainer ubuntuC = new UbuntuContainer(host, certPath)
+
+        ubuntuC.prepareVolumeMount(srcVolume.name, "/srcVolume")
+        ubuntuC.prepareVolumeMount(destVolume.name, "/destVolume", false)
+
+        ubuntuC.createSleepyContainer()
+        ubuntuC.startContainer()
+        ArrayList<String> cmdOut = ubuntuC.runBashCommandInContainer("cp -av /srcVolume/* /destVolume/ && echo status: \$?")
+        ubuntuC.stopAndRemoveContainer()
+        assert cmdOut.any { it == "status: 0" }: "Error copying data to cloned volume"
+        log.info("\tSuccessfully copied data to volume")
+
+        return destVolume
+
 
     }
 

--- a/src/main/groovy/com/eficode/devstack/util/TimeMachine.groovy
+++ b/src/main/groovy/com/eficode/devstack/util/TimeMachine.groovy
@@ -40,6 +40,12 @@ class TimeMachine implements Container {
     String defaultShell = "/bin/sh"
     UnirestInstance unirest = Unirest.spawnInstance()
 
+    TimeMachine(String dockerHost = "", String dockerCertPath = "") {
+        if (dockerHost && dockerCertPath) {
+            assert setupSecureRemoteConnection(dockerHost, dockerCertPath): "Error setting up secure remote docker connection"
+        }
+    }
+
     /**
      * Travel back to the present
      * <b>NEVER EVER</b> use this class on a production docker engine <p>

--- a/src/main/groovy/com/eficode/devstack/util/TimeMachine.groovy
+++ b/src/main/groovy/com/eficode/devstack/util/TimeMachine.groovy
@@ -1,6 +1,7 @@
 package com.eficode.devstack.util
 
 import com.eficode.devstack.container.Container
+import com.eficode.shaded.kong.unirest.Empty
 import de.gesellix.docker.remote.api.ContainerCreateRequest
 import kong.unirest.HttpResponse
 import kong.unirest.JsonResponse
@@ -38,8 +39,6 @@ class TimeMachine implements Container {
     String containerImage = "alpine"
     String containerImageTag = "latest"
     String defaultShell = "/bin/sh"
-    UnirestInstance unirest = Unirest.spawnInstance()
-
     TimeMachine(String dockerHost = "", String dockerCertPath = "") {
         if (dockerHost && dockerCertPath) {
             assert setupSecureRemoteConnection(dockerHost, dockerCertPath): "Error setting up secure remote docker connection"
@@ -171,11 +170,11 @@ class TimeMachine implements Container {
     }
 
     static long getExternalTime(){
-        HttpResponse<JsonResponse> response = Unirest.get("http://google.com").asJson() as HttpResponse<JsonResponse>
+        HttpResponse<Empty> response = Unirest.get("http://google.com").asEmpty() as HttpResponse<Empty>
         String dateString = response.headers["Date"].first()
-        def dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z")
+        SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z")
         Date date = dateFormat.parse(dateString)
-        return date.time / 1000
+        return (date.time / 1000).round()
     }
 
     /**

--- a/src/main/groovy/com/eficode/devstack/util/TimeMachine.groovy
+++ b/src/main/groovy/com/eficode/devstack/util/TimeMachine.groovy
@@ -53,7 +53,7 @@ class TimeMachine implements Container {
      * @param dockerCertPath optional
      * @return true after verifying success
      */
-    static boolean travelToNow(String dockerHost = "", String dockerCertPath = "", boolean useExternalSource) {
+    static boolean travelToNow(String dockerHost = "", String dockerCertPath = "", boolean useExternalSource = true) {
         if(useExternalSource){
             long timeFromExternal = getExternalTime()
             return setTime(timeFromExternal, dockerHost, dockerCertPath)

--- a/src/test/groovy/com/eficode/devstack/DevStackSpec.groovy
+++ b/src/test/groovy/com/eficode/devstack/DevStackSpec.groovy
@@ -19,9 +19,11 @@ import java.util.regex.Matcher
 class DevStackSpec extends Specification {
 
     @Shared
-    String dockerRemoteHost = "https://docker.domain.se:2376"
+    //String dockerRemoteHost = "https://docker.domain.se:2376"
+    String dockerRemoteHost = ""
     @Shared
-    String dockerCertPath = "~/.docker/"
+    //String dockerCertPath = "~/.docker/"
+    String dockerCertPath = ""
 
     @Shared
     DockerClientDS dockerClient

--- a/src/test/groovy/com/eficode/devstack/container/impl/DoodContainerTest.groovy
+++ b/src/test/groovy/com/eficode/devstack/container/impl/DoodContainerTest.groovy
@@ -12,7 +12,7 @@ class DoodContainerTest extends DevStackSpec {
         dockerCertPath = "~/.docker/"
 
 
-        log = LoggerFactory.getLogger(DoodContainerTest.class)
+        DevStackSpec.log = LoggerFactory.getLogger(DoodContainerTest.class)
 
 
         cleanupContainerNames = ["dood.domain.se"]

--- a/src/test/groovy/com/eficode/devstack/container/impl/JenkinsContainerTest.groovy
+++ b/src/test/groovy/com/eficode/devstack/container/impl/JenkinsContainerTest.groovy
@@ -4,7 +4,6 @@ import com.eficode.devstack.DevStackSpec
 import de.gesellix.docker.remote.api.ContainerState
 import de.gesellix.docker.remote.api.core.Frame
 import de.gesellix.docker.remote.api.core.StreamCallback
-import kong.unirest.HttpResponse
 import kong.unirest.Unirest
 import kong.unirest.UnirestInstance
 import org.slf4j.LoggerFactory
@@ -18,7 +17,7 @@ class JenkinsContainerTest extends DevStackSpec{
         dockerRemoteHost = "https://docker.domain.se:2376"
         dockerCertPath = "~/.docker/"
 
-        log = LoggerFactory.getLogger(JenkinsContainerTest.class)
+        DevStackSpec.log = LoggerFactory.getLogger(JenkinsContainerTest.class)
 
 
         cleanupContainerNames = ["jenkins.domain.se", "jenkins-agent.domain.se", "localhost"]
@@ -45,7 +44,7 @@ class JenkinsContainerTest extends DevStackSpec{
         long start = System.currentTimeMillis()
         //String baseUrl = "http://" + jc.containerName + ":" + jc.containerMainPort + "/login"
 
-        log.info("Waiting for Jenkins WEB-UI to become responsive")
+        DevStackSpec.log.info("Waiting for Jenkins WEB-UI to become responsive")
 
 
 
@@ -64,19 +63,19 @@ class JenkinsContainerTest extends DevStackSpec{
                 try {
                     int status = unirestInstance.get(baseUrl + "/login").socketTimeout(5000).connectTimeout(10000).asEmpty()?.status
                     if (status == 200){
-                        log.info("\tJenkins is ready and responded with HTTP status:" + status + " after " + ((System.currentTimeMillis() - start)/1000).round() + "s")
+                        DevStackSpec.log.info("\tJenkins is ready and responded with HTTP status:" + status + " after " + ((System.currentTimeMillis() - start)/1000).round() + "s")
                         break
                     }
                     else {
-                        log.info("\tJenkins responded with HTTP status:" + status)
+                        DevStackSpec.log.info("\tJenkins responded with HTTP status:" + status)
                         sleep(2000)
                     }
                 }catch(ex) {
-                    log.warn("\tError accessing Jenkins WEB-UI:" + ex.message)
+                    DevStackSpec.log.warn("\tError accessing Jenkins WEB-UI:" + ex.message)
                     sleep(2000)
                 }
             }else {
-                log.error("\tTimed our waiting for Jenkins after:" + ((System.currentTimeMillis() - start)/1000).round() + "s")
+                DevStackSpec.log.error("\tTimed our waiting for Jenkins after:" + ((System.currentTimeMillis() - start)/1000).round() + "s")
                 throw new TimeoutException("Error waiting for Jenkins WEB to become available:" + baseUrl)
             }
 

--- a/src/test/groovy/com/eficode/devstack/container/impl/JsmContainerTest.groovy
+++ b/src/test/groovy/com/eficode/devstack/container/impl/JsmContainerTest.groovy
@@ -19,7 +19,7 @@ class JsmContainerTest extends DevStackSpec {
         dockerCertPath = "~/.docker/"
 
 
-        log = LoggerFactory.getLogger(JsmContainerTest.class)
+        DevStackSpec.log = LoggerFactory.getLogger(JsmContainerTest.class)
 
         cleanupContainerNames = ["jira.domain.se", "JSM", "Spoc-JSM"]
         cleanupContainerPorts = [8080]
@@ -30,28 +30,28 @@ class JsmContainerTest extends DevStackSpec {
     def "test isCreated"(String dockerHost, String certPath) {
 
         when:
-        log.info("Testing isCreated")
+        DevStackSpec.log.info("Testing isCreated")
         JsmContainer jsm = new JsmContainer(dockerHost, certPath)
 
         then:
         !jsm.isCreated()
-        log.info("\tDid not return a false positive")
+        DevStackSpec.log.info("\tDid not return a false positive")
 
         when:
         String containerId = jsm.createContainer()
-        log.info("\tCreated container:" + containerId)
+        DevStackSpec.log.info("\tCreated container:" + containerId)
 
         then:
         jsm.isCreated()
-        log.info("\tisCreated now returns true")
+        DevStackSpec.log.info("\tisCreated now returns true")
 
         when:
         jsm.stopAndRemoveContainer() ?: {throw new Exception("Error revoming container $containerId")}
-        log.info("\tRemoved container")
+        DevStackSpec.log.info("\tRemoved container")
 
         then:
         !jsm.isCreated()
-        log.info("\tisCreated now again returns false")
+        DevStackSpec.log.info("\tisCreated now again returns false")
 
         where:
         dockerHost       | certPath
@@ -80,7 +80,7 @@ class JsmContainerTest extends DevStackSpec {
 
     def "test setupContainer"(String dockerHost, String certPath) {
         setup:
-        log.info("Testing setup of JSM container using trait method")
+        DevStackSpec.log.info("Testing setup of JSM container using trait method")
         JsmContainer jsm = new JsmContainer(dockerHost, certPath)
 
         when:
@@ -94,7 +94,7 @@ class JsmContainerTest extends DevStackSpec {
         assert containerInspect.state.running == false : "JSM Container was started even though it should only have been created"
         assert dockerClient.inspectImage(containerInspect.image).content.repoTags.find {it == "atlassian/jira-servicemanagement:latest"} : "JSM container was created with incorrect Docker image"
         assert containerInspect.hostConfig.portBindings.containsKey("8080/tcp") : "JSM Container port binding was not setup correctly"
-        log.info("\tJSM Container was setup correctly")
+        DevStackSpec.log.info("\tJSM Container was setup correctly")
 
 
         where:
@@ -108,7 +108,7 @@ class JsmContainerTest extends DevStackSpec {
 
     def "test non standard parameters"(String dockerHost, String certPath) {
         setup:
-        log.info("Testing setup of JSM container using dedicated JSM method")
+        DevStackSpec.log.info("Testing setup of JSM container using dedicated JSM method")
         JsmContainer jsm = new JsmContainer(dockerHost, certPath)
         jsm.containerName = "Spoc-JSM"
         jsm.containerImageTag = "4-ubuntu-jdk11"
@@ -125,7 +125,7 @@ class JsmContainerTest extends DevStackSpec {
         assert containerInspect.state.running == false : "JSM Container was started even though it should only have been created"
         assert containerInspect.hostConfig.portBindings.containsKey("666/tcp") : "JSM Container port binding was not setup correctly"
         assert dockerClient.inspectImage(containerInspect.image).content.repoTags.find {it == "atlassian/jira-servicemanagement:4-ubuntu-jdk11"} : "JSM container was created with incorrect Docker image"
-        log.info("\tJSM Container was setup correctly")
+        DevStackSpec.log.info("\tJSM Container was setup correctly")
 
 
         where:
@@ -137,50 +137,50 @@ class JsmContainerTest extends DevStackSpec {
 
 
 
-   def "test stopAndRemoveContainer"(String dockerHost, String certPath) {
+    def "test stopAndRemoveContainer"(String dockerHost, String certPath) {
 
 
-       setup:
-       log.info("Testing stop and removal of JSM container")
-       JsmContainer jsm = new JsmContainer(dockerHost, certPath)
+        setup:
+        DevStackSpec.log.info("Testing stop and removal of JSM container")
+        JsmContainer jsm = new JsmContainer(dockerHost, certPath)
 
-       when: "Setting up the container with the trait method"
-       log.info("\tSetting up JSM container using trait method")
-       String containerId = jsm.createContainer()
+        when: "Setting up the container with the trait method"
+        DevStackSpec.log.info("\tSetting up JSM container using trait method")
+        String containerId = jsm.createContainer()
 
-       then: "Removing it should return true"
-       jsm.stopAndRemoveContainer()
+        then: "Removing it should return true"
+        jsm.stopAndRemoveContainer()
 
-       when: "Inspecting the deleted container"
-       dockerClient.inspectContainer(containerId)
+        when: "Inspecting the deleted container"
+        dockerClient.inspectContainer(containerId)
 
-       then: "Exception should be thrown"
-       ClientException ex = thrown(ClientException)
-       assert ex.message.startsWith("Client error : 404 Not Found") : "Unexpected exception thrown when inspecting the deleted container"
-
-
-
-       when: "Setting up the container with the trait method"
-       log.info("\tSetting up JSM container using dedicated JSM method")
-       String containerId2 = jsm.createContainer()
-
-       then: "Removing it should return true"
-       jsm.stopAndRemoveContainer()
-
-       when: "Inspecting the deleted container"
-       dockerClient.inspectContainer(containerId2)
-
-       then: "Exception should be thrown"
-       ClientException ex2 = thrown(ClientException)
-       assert ex2.message.startsWith("Client error : 404 Not Found") : "Unexpected exception thrown when inspecting the deleted container"
-
-       where:
-       dockerHost       | certPath
-       ""               | ""
-       dockerRemoteHost | dockerCertPath
+        then: "Exception should be thrown"
+        ClientException ex = thrown(ClientException)
+        assert ex.message.startsWith("Client error : 404 Not Found") : "Unexpected exception thrown when inspecting the deleted container"
 
 
-   }
+
+        when: "Setting up the container with the trait method"
+        DevStackSpec.log.info("\tSetting up JSM container using dedicated JSM method")
+        String containerId2 = jsm.createContainer()
+
+        then: "Removing it should return true"
+        jsm.stopAndRemoveContainer()
+
+        when: "Inspecting the deleted container"
+        dockerClient.inspectContainer(containerId2)
+
+        then: "Exception should be thrown"
+        ClientException ex2 = thrown(ClientException)
+        assert ex2.message.startsWith("Client error : 404 Not Found") : "Unexpected exception thrown when inspecting the deleted container"
+
+        where:
+        dockerHost       | certPath
+        ""               | ""
+        dockerRemoteHost | dockerCertPath
+
+
+    }
 
     def "test startContainer, runBashCommandInContainer, copyFileToContainer and copyFilesFromContainer"(String dockerHost, String certPath) {
 
@@ -188,42 +188,42 @@ class JsmContainerTest extends DevStackSpec {
         String containerSrcPath = "/opt/atlassian/jira/atlassian-jira/WEB-INF/classes/com/atlassian/jira/"
         String containerDstDir = "/var/atlassian/application-data/jira/"
 
-        log.info("Testing copying files to and from JSM container")
+        DevStackSpec.log.info("Testing copying files to and from JSM container")
         JsmContainer jsm = new JsmContainer(dockerHost, certPath)
         String containerId = jsm.createContainer()
-        log.info("\tCreated container:" + containerId)
+        DevStackSpec.log.info("\tCreated container:" + containerId)
 
         Path tempDir = Files.createTempDirectory("testing-${this.class.simpleName}")
-        log.info("\tCreated temp dir:" + containerId.toString())
+        DevStackSpec.log.info("\tCreated temp dir:" + containerId.toString())
 
 
         when: "Copying files from container path:"
-        log.info("\tCopying files from container path:" + containerSrcPath)
+        DevStackSpec.log.info("\tCopying files from container path:" + containerSrcPath)
         ArrayList<File>copiedFiles = jsm.copyFilesFromContainer(containerSrcPath, tempDir.toString() + "/")
-        log.info("\tCopied ${copiedFiles.size()} files from container")
+        DevStackSpec.log.info("\tCopied ${copiedFiles.size()} files from container")
 
         then: "Several files and directories should have been copied"
         assert copiedFiles.size() : "No files where copied from container"
         assert copiedFiles.any {it.directory} : "No directories where copied from container"
-        log.info("\tCopying files from container appears successful")
+        DevStackSpec.log.info("\tCopying files from container appears successful")
 
         when: "Copying a file to container"
         assert jsm.startContainer() : "Error starting container"
 
         File largestFile = copiedFiles.sort {it.size()}.last()
         String fileHash = largestFile.bytes.sha256()
-        log.info("\tCopying file ($largestFile.name) to container path:" + containerDstDir + largestFile.name)
-        log.debug("\t\tFile size:" + (largestFile.size() * 0.000001).round(1) + "MB")
-        log.debug("\t\tFile hash:" + fileHash)
+        DevStackSpec.log.info("\tCopying file ($largestFile.name) to container path:" + containerDstDir + largestFile.name)
+        DevStackSpec.log.debug("\t\tFile size:" + (largestFile.size() * 0.000001).round(1) + "MB")
+        DevStackSpec.log.debug("\t\tFile hash:" + fileHash)
 
         then: "File should copy without error"
         jsm.copyFileToContainer(largestFile.path, containerDstDir)
-        log.info("\tFinished copying file to container")
+        DevStackSpec.log.info("\tFinished copying file to container")
 
         when: "Running a hash in the container"
-        log.info("Executing hash calculation of file in container")
+        DevStackSpec.log.info("Executing hash calculation of file in container")
         ArrayList<String> hashOutput = jsm.runBashCommandInContainer("sha256sum " + containerDstDir + largestFile.name)
-        log.debug("\tContainer hash output:" + hashOutput)
+        DevStackSpec.log.debug("\tContainer hash output:" + hashOutput)
 
         then: "The container hash and local hash should be identical"
         assert hashOutput.size() == 1 : "Expected one output row from remote bash command"
@@ -234,7 +234,7 @@ class JsmContainerTest extends DevStackSpec {
 
 
         cleanup:
-        log.info("\tDeleting temp dir:" + tempDir.toString())
+        DevStackSpec.log.info("\tDeleting temp dir:" + tempDir.toString())
         FileUtils.deleteDirectory(tempDir.toFile())
 
 

--- a/src/test/groovy/com/eficode/devstack/container/impl/NginxContainerTest.groovy
+++ b/src/test/groovy/com/eficode/devstack/container/impl/NginxContainerTest.groovy
@@ -5,7 +5,6 @@ import com.eficode.devstack.deployment.impl.NginxFileServer
 import de.gesellix.docker.remote.api.ContainerInspectResponse
 import kong.unirest.Unirest
 import org.slf4j.LoggerFactory
-import spock.lang.Shared
 
 class NginxContainerTest extends DevStackSpec {
 
@@ -118,7 +117,7 @@ class NginxContainerTest extends DevStackSpec {
         nginxC.bindHtmlRoot(localNginxRoot, false)
 
         then:
-        nginxC.mounts.size() == 1
+        nginxC.preparedMounts.size() == 1
 
         when: "After creating the container, the inspect result should confirm the mount"
         String containerId = nginxC.createContainer()

--- a/src/test/groovy/com/eficode/devstack/container/impl/NginxContainerTest.groovy
+++ b/src/test/groovy/com/eficode/devstack/container/impl/NginxContainerTest.groovy
@@ -16,7 +16,7 @@ class NginxContainerTest extends DevStackSpec {
         dockerCertPath = "~/.docker/"
 
 
-        log = LoggerFactory.getLogger(this.class)
+        DevStackSpec.log = LoggerFactory.getLogger(this.class)
 
         cleanupContainerNames = ["Nginx", "Nginx-File-Server"]
         cleanupContainerPorts = [80]
@@ -108,8 +108,8 @@ class NginxContainerTest extends DevStackSpec {
 
         setup:
         String localNginxRoot = "/tmp/"
-        log.info("Testing setting nginx root dir")
-        log.info("\tWill use dir:" + localNginxRoot)
+        DevStackSpec.log.info("Testing setting nginx root dir")
+        DevStackSpec.log.info("\tWill use dir:" + localNginxRoot)
 
         NginxContainer nginxC = new NginxContainer(dockerHost, certPath)
         //stopAndRemoveContainer([nginxC.containerName])
@@ -122,14 +122,14 @@ class NginxContainerTest extends DevStackSpec {
 
         when: "After creating the container, the inspect result should confirm the mount"
         String containerId = nginxC.createContainer()
-        log.info("\tCreated container:" + containerId)
+        DevStackSpec.log.info("\tCreated container:" + containerId)
         assert nginxC.startContainer(): "Error starting container"
         ContainerInspectResponse inspectResponse = dockerClient.inspectContainer(nginxC.id).getContent()
-        log.info("\tContainer created")
+        DevStackSpec.log.info("\tContainer created")
 
         then:
         inspectResponse.hostConfig.mounts.find { it.source == localNginxRoot }
-        log.info("\tDocker API confirms mount was created")
+        DevStackSpec.log.info("\tDocker API confirms mount was created")
 
         when: "Creating a file in the mounted dir"
         ArrayList<String> cmdOutput = nginxC.runBashCommandInContainer("mkdir -p /usr/share/nginx/html/nginxTest && touch /usr/share/nginx/html/nginxTest/a.file && echo status: \$?")

--- a/src/test/groovy/com/eficode/devstack/container/impl/TimeMachineSpec.groovy
+++ b/src/test/groovy/com/eficode/devstack/container/impl/TimeMachineSpec.groovy
@@ -194,7 +194,7 @@ class TimeMachineSpec extends DevStackSpec {
         return timeTraveler
     }
 
-    boolean waitForJiraToBeResponsive(JsmH2Deployment deployment, long timeoustS = 90) {
+    boolean waitForJiraToBeResponsive(JsmH2Deployment deployment, long timeOutS = 90) {
         UnirestInstance jsmUnirest = deployment.jiraRest.getUnirest()
 
         HttpResponse<Map> response = null
@@ -208,7 +208,7 @@ class TimeMachineSpec extends DevStackSpec {
 
                 response = jsmUnirest.get("/status").asObject(Map.class).ifFailure { log.warn("JSM container not yet responsive") }
 
-                if ((start + timeoustS) < System.currentTimeSeconds()) {
+                if ((start + timeOutS) < System.currentTimeSeconds()) {
                     log.error("Timed out waiting for JSM to start after ${System.currentTimeSeconds() - start} seconds")
                     return false
                 }
@@ -232,7 +232,7 @@ class TimeMachineSpec extends DevStackSpec {
             } catch (ignored) {
             }
 
-            if ((start + timeoustS) < System.currentTimeSeconds()) {
+            if ((start + timeOutS) < System.currentTimeSeconds()) {
                 log.error("Timed out waiting for JSM to start after ${System.currentTimeSeconds() - start} seconds")
                 return false
             }

--- a/src/test/groovy/com/eficode/devstack/container/impl/TimeMachineSpec.groovy
+++ b/src/test/groovy/com/eficode/devstack/container/impl/TimeMachineSpec.groovy
@@ -1,0 +1,153 @@
+package com.eficode.devstack.container.impl
+
+import com.eficode.devstack.DevStackSpec
+import com.eficode.devstack.container.Container
+import com.eficode.devstack.util.TimeMachine
+import org.slf4j.LoggerFactory
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+
+class TimeMachineSpec extends DevStackSpec{
+
+    long okTimeDiffS = 3
+    ZoneOffset defaultZoneOffset =  ZoneId.systemDefault().offset
+
+
+
+    def setupSpec() {
+
+        DevStackSpec.log = LoggerFactory.getLogger(this.class)
+
+        cleanupContainerNames = []
+        cleanupContainerPorts = []
+
+        disableCleanup = false
+
+
+    }
+
+    //Run after every test
+    @Override
+    def cleanup() {
+        if (!disableCleanup) {
+            cleanupContainers()
+            cleanupNetworks()
+        }
+
+    }
+
+    boolean restoreDockerEngineTime() {
+
+        long realTime = TimeMachine.getExternalTime()
+        long dockerTime = TimeMachine.getDockerTime(dockerRemoteHost, dockerCertPath)
+
+        long timeDiff = (realTime - dockerTime).abs()
+
+        if ( timeDiff > okTimeDiffS) {
+            log.info("Restoring real time in docker engine, time diffs $timeDiff seconds")
+            assert TimeMachine.setTime(realTime, dockerRemoteHost, dockerCertPath) : "Error setting new docker time"
+            log.info("\tSuccessfully restored time in Docker Engine")
+        }else {
+            log.info("The time diff between docker engine and reality is acceptable:" + timeDiff)
+        }
+
+        return true
+    }
+
+
+    long getEpochS(LocalDate localDate) {
+        return localDate.toEpochSecond(LocalTime.of(0, 0), defaultZoneOffset)
+    }
+    long getEpochS(LocalDateTime localDateTime) {
+        localDateTime.toEpochSecond(defaultZoneOffset)
+    }
+
+    long getContainerTime(Container container ) {
+
+        ArrayList<String> cmdOut = container.runBashCommandInContainer('date +"%s"', 10)
+        long timeStamp = cmdOut.find { it.isNumber() }?.toLong() ?: 0
+        assert timeStamp: "Unexpected output when getting container time"
+
+        return timeStamp
+    }
+
+    def "Test comparing docker time with external and local"() {
+
+        setup:
+        log.info("Testing comparing time between docker container and external time, and local machine time")
+        assert restoreDockerEngineTime() : "Error restoring docker engine time"
+        log.info("\tSuccessfully restored time in docker engine")
+
+
+        long dockerTime = TimeMachine.getDockerTime(dockerRemoteHost, dockerCertPath)
+        long realTime = TimeMachine.getExternalTime()
+        long localTIme = new Date().toInstant().epochSecond
+
+        log.debug("\tGot Timestamps:")
+        log.debug("\t"*2 + "Time in docker engine:\t" + dockerTime)
+        log.debug("\t"*2 + "Time according to external source:\t" + realTime)
+        log.debug("\t"*2 + "Time according to local machine:\t" + localTIme)
+
+
+        long dockerToExternalDiff = (realTime - dockerTime).abs()
+        long dockerToLocalDiff = (localTIme - dockerTime).abs()
+        log.info("\tTime diff between docker and reality is: " + dockerToExternalDiff + "s")
+        log.info("\tTime diff between docker and local machine is: " + dockerToLocalDiff + "s")
+
+
+        expect:
+        assert dockerToExternalDiff <= okTimeDiffS : "Docker Time and external time appears to be different after restoring it"
+        log.info("\tDocker time and external time are the same ")
+        assert dockerToLocalDiff <= okTimeDiffS : "Docker Time and local time appears to be different after restoring it"
+        log.info("\tDocker time and local machine time are the same ")
+
+    }
+
+    def "Test time travel on companion containers"() {
+
+        setup:
+        assert restoreDockerEngineTime() : "Error restoring docker engine time"
+        UbuntuContainer timeTraveler = new UbuntuContainer(dockerRemoteHost, dockerCertPath)
+        timeTraveler.containerName = "TimeTraveler"
+        timeTraveler.createSleepyContainer()
+        assert timeTraveler.startContainer() : "Error starting time traveler container"
+        assert (getContainerTime(timeTraveler) - TimeMachine.getExternalTime()).abs() <= okTimeDiffS
+        log.info("\tTime in the TimeTraveler container was realTime before test")
+
+        when: "Traveling forward in time, after having an already running companion container"
+        LocalDateTime tomorrow = LocalDateTime.now().plusDays(1)
+        long tomorrowS = getEpochS(tomorrow)
+        log.info("\tWill travel to tomorrow:" + tomorrow + " ($tomorrowS)")
+        assert TimeMachine.setLocalDateTime( tomorrow, dockerRemoteHost, dockerCertPath) : "TimeMachine container errord when traveling to $tomorrow"
+        log.info("\tTime as updated using the TimeMachine")
+
+
+        then: "Time in the companion should be updated after the change"
+        (getContainerTime(timeTraveler) - tomorrowS).abs() <= okTimeDiffS
+        log.info("\tTime travel was reflected in the already running companion container")
+
+        when: "When starting a new companion container, after having travelled forward in time"
+        timeTraveler.stopAndRemoveContainer()
+        timeTraveler = new UbuntuContainer(dockerRemoteHost, dockerCertPath)
+        timeTraveler.containerName = "TimeTraveler"
+        timeTraveler.createSleepyContainer()
+        assert timeTraveler.startContainer() : "Error starting time traveler container"
+
+        then: "The time in the new container should also be in the future"
+        assert (getContainerTime(timeTraveler) - tomorrowS).abs() <= (okTimeDiffS * 5)
+
+
+
+        cleanup:
+        timeTraveler.stopAndRemoveContainer()
+
+
+    }
+
+
+}

--- a/src/test/groovy/com/eficode/devstack/container/impl/TimeMachineSpec.groovy
+++ b/src/test/groovy/com/eficode/devstack/container/impl/TimeMachineSpec.groovy
@@ -2,6 +2,7 @@ package com.eficode.devstack.container.impl
 
 import com.eficode.devstack.DevStackSpec
 import com.eficode.devstack.container.Container
+import com.eficode.devstack.deployment.impl.JsmH2Deployment
 import com.eficode.devstack.util.TimeMachine
 import org.slf4j.LoggerFactory
 
@@ -12,11 +13,11 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 
 
-class TimeMachineSpec extends DevStackSpec{
+class TimeMachineSpec extends DevStackSpec {
 
-    long okTimeDiffS = 3
-    ZoneOffset defaultZoneOffset =  ZoneId.systemDefault().offset
 
+    long okTimeDiffS = 3 //The nr of seconds that considered OK for time to diff in most circumstances during testing
+    ZoneOffset defaultZoneOffset = ZoneId.systemDefault().offset
 
 
     def setupSpec() {
@@ -26,7 +27,7 @@ class TimeMachineSpec extends DevStackSpec{
         cleanupContainerNames = []
         cleanupContainerPorts = []
 
-        disableCleanup = false
+        disableCleanup = true
 
 
     }
@@ -48,11 +49,11 @@ class TimeMachineSpec extends DevStackSpec{
 
         long timeDiff = (realTime - dockerTime).abs()
 
-        if ( timeDiff > okTimeDiffS) {
+        if (timeDiff > okTimeDiffS) {
             log.info("Restoring real time in docker engine, time diffs $timeDiff seconds")
-            assert TimeMachine.setTime(realTime, dockerRemoteHost, dockerCertPath) : "Error setting new docker time"
+            assert TimeMachine.setTime(realTime, dockerRemoteHost, dockerCertPath): "Error setting new docker time"
             log.info("\tSuccessfully restored time in Docker Engine")
-        }else {
+        } else {
             log.info("The time diff between docker engine and reality is acceptable:" + timeDiff)
         }
 
@@ -63,11 +64,12 @@ class TimeMachineSpec extends DevStackSpec{
     long getEpochS(LocalDate localDate) {
         return localDate.toEpochSecond(LocalTime.of(0, 0), defaultZoneOffset)
     }
+
     long getEpochS(LocalDateTime localDateTime) {
         localDateTime.toEpochSecond(defaultZoneOffset)
     }
 
-    long getContainerTime(Container container ) {
+    long getContainerTime(Container container) {
 
         ArrayList<String> cmdOut = container.runBashCommandInContainer('date +"%s"', 10)
         long timeStamp = cmdOut.find { it.isNumber() }?.toLong() ?: 0
@@ -80,7 +82,7 @@ class TimeMachineSpec extends DevStackSpec{
 
         setup:
         log.info("Testing comparing time between docker container and external time, and local machine time")
-        assert restoreDockerEngineTime() : "Error restoring docker engine time"
+        assert restoreDockerEngineTime(): "Error restoring docker engine time"
         log.info("\tSuccessfully restored time in docker engine")
 
 
@@ -89,9 +91,9 @@ class TimeMachineSpec extends DevStackSpec{
         long localTIme = new Date().toInstant().epochSecond
 
         log.debug("\tGot Timestamps:")
-        log.debug("\t"*2 + "Time in docker engine:\t" + dockerTime)
-        log.debug("\t"*2 + "Time according to external source:\t" + realTime)
-        log.debug("\t"*2 + "Time according to local machine:\t" + localTIme)
+        log.debug("\t" * 2 + "Time in docker engine:\t" + dockerTime)
+        log.debug("\t" * 2 + "Time according to external source:\t" + realTime)
+        log.debug("\t" * 2 + "Time according to local machine:\t" + localTIme)
 
 
         long dockerToExternalDiff = (realTime - dockerTime).abs()
@@ -101,21 +103,21 @@ class TimeMachineSpec extends DevStackSpec{
 
 
         expect:
-        assert dockerToExternalDiff <= okTimeDiffS : "Docker Time and external time appears to be different after restoring it"
+        assert dockerToExternalDiff <= okTimeDiffS: "Docker Time and external time appears to be different after restoring it"
         log.info("\tDocker time and external time are the same ")
-        assert dockerToLocalDiff <= okTimeDiffS : "Docker Time and local time appears to be different after restoring it"
+        assert dockerToLocalDiff <= okTimeDiffS: "Docker Time and local time appears to be different after restoring it"
         log.info("\tDocker time and local machine time are the same ")
 
     }
 
-    def "Test time travel on companion containers"() {
+    def "Verify companion Ubuntu containers created before and after time travel are affected by the changes"() {
 
         setup:
-        assert restoreDockerEngineTime() : "Error restoring docker engine time"
+        assert restoreDockerEngineTime(): "Error restoring docker engine time"
         UbuntuContainer timeTraveler = new UbuntuContainer(dockerRemoteHost, dockerCertPath)
         timeTraveler.containerName = "TimeTraveler"
         timeTraveler.createSleepyContainer()
-        assert timeTraveler.startContainer() : "Error starting time traveler container"
+        assert timeTraveler.startContainer(): "Error starting time traveler container"
         assert (getContainerTime(timeTraveler) - TimeMachine.getExternalTime()).abs() <= okTimeDiffS
         log.info("\tTime in the TimeTraveler container was realTime before test")
 
@@ -123,7 +125,7 @@ class TimeMachineSpec extends DevStackSpec{
         LocalDateTime tomorrow = LocalDateTime.now().plusDays(1)
         long tomorrowS = getEpochS(tomorrow)
         log.info("\tWill travel to tomorrow:" + tomorrow + " ($tomorrowS)")
-        assert TimeMachine.setLocalDateTime( tomorrow, dockerRemoteHost, dockerCertPath) : "TimeMachine container errord when traveling to $tomorrow"
+        assert TimeMachine.setLocalDateTime(tomorrow, dockerRemoteHost, dockerCertPath): "TimeMachine container errord when traveling to $tomorrow"
         log.info("\tTime as updated using the TimeMachine")
 
 
@@ -136,15 +138,86 @@ class TimeMachineSpec extends DevStackSpec{
         timeTraveler = new UbuntuContainer(dockerRemoteHost, dockerCertPath)
         timeTraveler.containerName = "TimeTraveler"
         timeTraveler.createSleepyContainer()
-        assert timeTraveler.startContainer() : "Error starting time traveler container"
+        assert timeTraveler.startContainer(): "Error starting time traveler container"
 
         then: "The time in the new container should also be in the future"
         assert (getContainerTime(timeTraveler) - tomorrowS).abs() <= (okTimeDiffS * 5)
 
 
-
         cleanup:
         timeTraveler.stopAndRemoveContainer()
+
+
+    }
+
+    JsmH2Deployment setupJsm() {
+
+        String jsmLicense = new File(System.getProperty("user.home") + "/.licenses/jira/jsm.license").text
+        String srLicense = new File(System.getProperty("user.home") + "/.licenses/jira/sr.license").text
+        assert jsmLicense: "Error finding JSM license"
+        assert srLicense: "Error finding script runner license"
+
+        JsmH2Deployment timeTraveler = new JsmH2Deployment("http://jsmtime.localhost:8060", dockerRemoteHost, dockerCertPath)
+        timeTraveler.setJiraLicense(jsmLicense)
+        timeTraveler.stopAndRemoveDeployment()
+        timeTraveler.setupDeployment()
+        assert timeTraveler.jiraRest.installScriptRunner(srLicense, "latest"): "Error installing ScriptRunner in JSM"
+        log.info("\tScriptRunner was installed")
+
+        return timeTraveler
+    }
+
+    long getJsmGroovyTime(JsmH2Deployment jsmDeploy) {
+
+        Map rawOut = jsmDeploy.jiraRest.executeLocalScriptFile("log.warn(\"EPOCH:\" + new Date().toInstant().epochSecond)")
+
+        assert rawOut.success == true : "There was an error querying for GroovyTime from JSM ScriptRunner"
+        assert (rawOut.log as ArrayList<String>).size() == 1
+
+        String rawLogStatement = (rawOut.log as ArrayList<String>).get(0)
+        long epochS = rawLogStatement.substring(rawLogStatement.lastIndexOf(":") + 1).toLong()
+
+        return epochS
+
+    }
+
+    def "Verify companion JSM containers created before and after time travel are affected by the changes"() {
+
+        setup:
+        assert restoreDockerEngineTime(): "Error restoring docker engine time"
+
+
+        JsmH2Deployment timeTraveler = setupJsm()
+        assert timeTraveler.jsmContainer.running: "Error starting time traveler container"
+        log.info("\tJSM has been setup")
+        assert (getContainerTime(timeTraveler.jsmContainer) - TimeMachine.getExternalTime()).abs() <= okTimeDiffS
+        log.info("\tTime in the TimeTraveler container was realTime before test")
+
+        when: "Traveling forward in time, after having an already running companion container"
+        LocalDateTime tomorrow = LocalDateTime.now().plusDays(1)
+        long tomorrowS = getEpochS(tomorrow)
+        log.info("\tWill travel to tomorrow:" + tomorrow + " ($tomorrowS)")
+        assert TimeMachine.setLocalDateTime(tomorrow, dockerRemoteHost, dockerCertPath): "TimeMachine container errord when traveling to $tomorrow"
+        log.info("\tTime was updated using the TimeMachine")
+
+
+        then: "Time in the companion should be updated after the change"
+        (getContainerTime(timeTraveler.jsmContainer) - tomorrowS).abs() <= okTimeDiffS
+        log.info("\tTime travel was reflected in the already running companion container")
+        getJsmGroovyTime(timeTraveler)
+
+        when: "When starting a new companion container, after having travelled forward in time"
+        timeTraveler.stopAndRemoveDeployment()
+        timeTraveler = setupJsm()
+        assert timeTraveler.jsmContainer.running: "Error starting time traveler container"
+
+        then: "The time in the new container should also be in the future"
+        assert (getContainerTime(timeTraveler.jsmContainer) - tomorrowS).abs() <= (okTimeDiffS * 5)
+
+
+
+        cleanup:
+        timeTraveler.stopAndRemoveDeployment()
 
 
     }

--- a/src/test/groovy/com/eficode/devstack/deployment/impl/BitbucketH2DeploymentTest.groovy
+++ b/src/test/groovy/com/eficode/devstack/deployment/impl/BitbucketH2DeploymentTest.groovy
@@ -1,11 +1,7 @@
 package com.eficode.devstack.deployment.impl
 
 import com.eficode.devstack.DevStackSpec
-import com.eficode.devstack.util.DockerClientDS
-import de.gesellix.docker.engine.DockerClientConfig
-import de.gesellix.docker.engine.DockerEnv
 import kong.unirest.Unirest
-import org.apache.commons.io.FileUtils
 import org.slf4j.LoggerFactory
 import spock.lang.Shared
 
@@ -23,8 +19,7 @@ class BitbucketH2DeploymentTest extends DevStackSpec{
         //dockerCertPath = "~/.docker/"
 
 
-
-        log = LoggerFactory.getLogger(BitbucketH2DeploymentTest.class)
+        DevStackSpec.log = LoggerFactory.getLogger(BitbucketH2DeploymentTest.class)
 
         cleanupContainerNames = ["bitbucket.domain.se", "bitbucket2.domain.se" , "localhost"]
         cleanupContainerPorts = [7990, 7992, 80]

--- a/src/test/groovy/com/eficode/devstack/deployment/impl/HarborDeploymentTest.groovy
+++ b/src/test/groovy/com/eficode/devstack/deployment/impl/HarborDeploymentTest.groovy
@@ -14,7 +14,7 @@ class HarborDeploymentTest extends DevStackSpec {
         //dockerCertPath = "~/.docker/"
 
 
-        log = LoggerFactory.getLogger(HarborDeploymentTest.class)
+        DevStackSpec.log = LoggerFactory.getLogger(HarborDeploymentTest.class)
 
         cleanupContainerPorts = [80]
 
@@ -76,7 +76,7 @@ class HarborDeploymentTest extends DevStackSpec {
         containerIdsBeforeStart.sort() == hd.getHarborContainers().id.sort()
         hd.getContainers().every { it.status() == ContainerState.Status.Running }
         Unirest.get(harborBaseUrl).basicAuth("admin", "Harbor12345").asEmpty().status == 200
-        log.info("\tSuccessful harbor Web login! ")
+        DevStackSpec.log.info("\tSuccessful harbor Web login! ")
 
         when:
         hd.stopAndRemoveDeployment()

--- a/src/test/groovy/com/eficode/devstack/deployment/impl/JenkinsAndHarborDeploymentTest.groovy
+++ b/src/test/groovy/com/eficode/devstack/deployment/impl/JenkinsAndHarborDeploymentTest.groovy
@@ -12,7 +12,7 @@ class JenkinsAndHarborDeploymentTest extends DevStackSpec {
         dockerCertPath = "~/.docker/"
 
 
-        log = LoggerFactory.getLogger(JsmH2DeploymentTest.class)
+        DevStackSpec.log = LoggerFactory.getLogger(JsmH2DeploymentTest.class)
 
 
         cleanupContainerNames = [

--- a/src/test/groovy/com/eficode/devstack/deployment/impl/JsmAndBitbucketH2DeploymentTest.groovy
+++ b/src/test/groovy/com/eficode/devstack/deployment/impl/JsmAndBitbucketH2DeploymentTest.groovy
@@ -31,7 +31,7 @@ class JsmAndBitbucketH2DeploymentTest extends DevStackSpec {
         dockerCertPath = "~/.docker/"
 
 
-        log = LoggerFactory.getLogger(JsmH2DeploymentTest.class)
+        DevStackSpec.log = LoggerFactory.getLogger(JsmH2DeploymentTest.class)
 
 
         cleanupContainerNames = ["jira.domain.se", "jira2.domain.se", "bitbucket.domain.se", "bitbucket2.domain.se"]

--- a/src/test/groovy/com/eficode/devstack/deployment/impl/JsmH2DeploymentTest.groovy
+++ b/src/test/groovy/com/eficode/devstack/deployment/impl/JsmH2DeploymentTest.groovy
@@ -19,7 +19,7 @@ class JsmH2DeploymentTest extends DevStackSpec {
         //dockerCertPath = "~/.docker/"
 
 
-        log = LoggerFactory.getLogger(JsmH2DeploymentTest.class)
+        DevStackSpec.log = LoggerFactory.getLogger(JsmH2DeploymentTest.class)
 
 
         cleanupContainerNames = ["jira.domain.se", "jira2.domain.se", "localhost"]

--- a/src/test/groovy/com/eficode/devstack/examples/ExamplesTest.groovy
+++ b/src/test/groovy/com/eficode/devstack/examples/ExamplesTest.groovy
@@ -13,11 +13,11 @@ class ExamplesTest extends DevStackSpec{
     @Shared
     File projectRoot = new File(".").canonicalFile
     @Shared
-    File jsmLicenseFile = new File(projectRoot.path + "/resources/jira/licenses/jsm.license")
+    File jsmLicenseFile = new File(System.getProperty("user.home") + "/.licenses/jira/jsm.license")
     @Shared
-    File bitbucketLicenseFile = new File(projectRoot.path + "/resources/bitbucket/licenses/bitbucketLicense")
+    File bitbucketLicenseFile = new File(System.getProperty("user.home") + "/.licenses/bitbucket/bitbucket.license")
     @Shared
-    File srLicenseFile = new File(projectRoot.path + "/resources/jira/licenses/scriptrunnerForJira.license")
+    File srLicenseFile = new File(System.getProperty("user.home") + "/.licenses/jira/sr.license")
 
 
     def setupSpec() {
@@ -27,7 +27,7 @@ class ExamplesTest extends DevStackSpec{
         dockerRemoteHost = ""
 
 
-        log = LoggerFactory.getLogger(ExamplesTest.class)
+        DevStackSpec.log = LoggerFactory.getLogger(ExamplesTest.class)
 
         cleanupContainerNames = ["groovy-container", "jira.local", "bitbucket.local"]
         cleanupContainerPorts = [8080,7990]


### PR DESCRIPTION
Solved kotlin shading issue caused by kotlinx.coroutines
Bumped version from 2.3.9 to 2.3.11
Bumped JiraInstanceManagerRest to 2.0.3
Container:
BREAKING: mounts variable/field is now called preparedMounts
Added prepareVolumeMount()
Added getShortId()
stopContainer now has a parameter for timeout and added logging
createTar() now has a parameter for ignoring paths and now supports long filenames/paths
added getHomePath()
copyFileToContainer() now has a parameter for ignoring paths
GroovyContainer

Still work in progress
Added createGroovyBuildContainer(), setUserLocalM2Cache(), installMaven/Git, cloneGitRepo, resolveMavenDependencies, generateEffectivePom, installMavenProject
GroovyBuilderDeployment

A new WIP deployment
JsmContainer

Added getJiraHomeMountPoint()
Added snapshot capabilities with restoreJiraHomeSnapshot, getSnahpshotVolume, snapshotJiraHome, cloneJiraHome
JsmH2Deployment

appsToInstall can now contain both URLs and MarketPlace.Versions
setupDeployment() now has an overloaded method for dealing with snapshots
NginxFileServer

Solved bug where network was not properly setup
DockerClientDS

Added volume commands
TImeMachine

travelToNow now defaults to using external source for time